### PR TITLE
Fixed unexpanded directory name bug

### DIFF
--- a/git-backup.el
+++ b/git-backup.el
@@ -84,7 +84,7 @@
   "Initialize git repository. GIT-BINARY-PATH is the absolute path where git stands, BACKUP-PATH is the path where backups are stored."
   (unless (file-directory-p
            backup-path)
-    (call-process git-binary-path nil nil nil "init" backup-path)
+    (call-process git-binary-path nil nil nil "init" (expand-file-name backup-path))
     (git-backup--exec-git-command git-binary-path backup-path (list "config" "--local" "user.email" "noemail@noemail.com"))
     (git-backup--exec-git-command git-binary-path backup-path (list "config" "--local" "user.name" "noname"))))
 


### PR DESCRIPTION
So if I feed `git-backup-version-file` with the `backup-path` of `~/.git-backup` (or any path starting with `~`) it doesn't create a new repo if `~/.git-backup` doesn't exist, it only creates a new directory. But if I feed it `/home/USER/.git-backup` it works fine. This change fixes it as far as I can see by expanding the path