### PR TITLE
Point is now kept on buffer replace

### DIFF
--- a/git-backup.el
+++ b/git-backup.el
@@ -67,8 +67,11 @@
 
 (defun git-backup-replace-current-buffer (git-binary-path backup-path commit-id filename)
   "Replace current buffer with backup using COMMIT-ID and FILENAME. GIT-BINARY-PATH is the absolute path where git stands, BACKUP-PATH is the path where backups are stored."
-  (erase-buffer)
-  (insert (git-backup--fetch-backup-file git-binary-path backup-path commit-id filename)))
+  (let ((pt (point)))
+    (erase-buffer)
+    (insert (git-backup--fetch-backup-file git-binary-path backup-path commit-id filename))
+    (goto-char pt)
+    (recenter)))
 
 (defun git-backup-create-ediff (git-binary-path backup-path commit-id buffer)
   "Create a ediff buffer with backup using COMMIT-ID and existing BUFFER. GIT-BINARY-PATH is the absolute path where git stands, BACKUP-PATH is the path where backups are stored."


### PR DESCRIPTION
This prevents the point from being reset every time you replace the current buffer. `save-excursion` can't be used here because it resets the point when the buffer is erased. The screen position isn't saved but at least it centers it on the point. Also a lot of other stuff like narrowing is still lost when the buffer is replaced but this change at least makes it a lot easier to go back in large files. It would be nice if there was a better way of doing this but I haven't found any